### PR TITLE
Use correct PHP docker image for Mac and Linux.

### DIFF
--- a/.docker/docker-compose.yml
+++ b/.docker/docker-compose.yml
@@ -34,14 +34,15 @@ services:
       DB_DRIVER: $DB_DRIVER
 
   nginx:
-    image: wodby/drupal-nginx:$NGINX_TAG
+    image: wodby/nginx:$NGINX_TAG
     depends_on:
       - php
     environment:
-      NGINX_STATIC_CONTENT_OPEN_FILE_CACHE: "off"
+      NGINX_STATIC_OPEN_FILE_CACHE: "off"
       NGINX_ERROR_LOG_LEVEL: debug
       NGINX_BACKEND_HOST: php
       NGINX_SERVER_ROOT: /var/www/html/web
+      NGINX_VHOST_PRESET: $NGINX_VHOST_PRESET
     labels:
       - 'traefik.backend=nginx'
       - 'traefik.port=80'

--- a/.env.default
+++ b/.env.default
@@ -16,5 +16,9 @@ DB_DRIVER=mysql
 # Container versions.
 NODE_TAG=8.11-0.3.0
 MARIADB_TAG=10.1-3.2.2
-PHP_TAG=7.2-dev-4.5.2
-NGINX_TAG=8-1.13-2.4.2
+# MacOS.
+PHP_TAG=7.2-dev-macos-4.6.0
+# Linux.
+# PHP_TAG=7.2-dev-4.6.0
+NGINX_TAG=1.13-5.0.0
+NGINX_VHOST_PRESET=drupal8

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
 # Installation
 
-1. Clone git repo locally, then
+1. Project setup is Mac by default, so if you are running MacOS then
 
     ```
     cd drupal_reactjs_boilerplate
     make install
     ```
 
-2. That's it, the app is ready!
- 
+2. If you happen to run Linux then
+    - run `make stop` command to create local environment files
+    - edit the created .env file to change the PHP_TAG value to the Linux one
+    - run `make install`
+
+3. That's it, the app is ready!
+
 # Access applications
  
 | URL                                     | Name                |


### PR DESCRIPTION
docker4drupal supplies different PHP images for Mac and Linux - we should use the correct versions. I have implemented it with project setup being Mac by default.