### PR TITLE
[WIP] Cover frontend API request in acceptance tests.

### DIFF
--- a/tests/acceptance/example/ExampleCest.php
+++ b/tests/acceptance/example/ExampleCest.php
@@ -15,6 +15,10 @@ class ExampleCest {
 
     $I->wantTo('Make sure admin user data can be fetched from Drupal');
     $I->see('admin');
+
+    $I->wantTo('Make sure API requests work from client side.');
+    $I->click('Home');
+    $I->see('admin');
   }
 
   /**


### PR DESCRIPTION
## Problem:

Current testing domains setup doesn't allow making API requests from headless Chrome to the backend.
What happens:
- Codeception (`codecept` container) passes `app.docker.local` to Chrome as the primary domain
- Frontend app (`node` container) uses `BACKEND_URL` (`app.docker.localhost`) variable to make API requests. 
- It works on Next.js server-side: API request is being sent from `node` container.
- It doesn't work on client side: API request from `chrome` container.

See demo here: https://circleci.com/gh/systemseed/drupal_reactjs_boilerplate/52
Screenshot: https://www.dropbox.com/s/5ptsaq5p52a5b3r/Screenshot_2018-10-28_19_25_01.jpg?dl=0

